### PR TITLE
Increase version for various bugfixes that happened over the years

### DIFF
--- a/cookiejar.nimble
+++ b/cookiejar.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "ringabout"
 description   = "HTTP Cookies for Nim."
 license       = "Apache-2.0"


### PR DESCRIPTION
This was triggered by nimble not providing the current cookies.nim file, but one from the time the 0.3.0 release was tagged. This causes buggy behavior with cookies that are supposed to be SameSite.None as they do not receive that string in their cookie header.